### PR TITLE
fix: iqs-20241111: type error

### DIFF
--- a/iqs-20241111/src/client.ts
+++ b/iqs-20241111/src/client.ts
@@ -78,6 +78,7 @@ export default class Client extends OpenApi {
     let sseResp = await this.callSSEApi(params, req, runtime);
 
     for await (let resp of sseResp) {
+      if (!resp.event.data) continue;
       let data = JSON.parse(resp.event.data);
       yield $dara.cast<$_model.AiSearchResponse>({
         statusCode: resp.statusCode,


### PR DESCRIPTION
error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

81       let data = JSON.parse(resp.event.data);
